### PR TITLE
CMAKE clean up: set variables to choose which executable should be built...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,12 @@ cmake_install.cmake
 # Unused rep files
 old
 
-# 2dview
-demo
+# QT5 moc files
+*automoc*
 moc_view.cpp
+
+# 2dview files
+2d_view
+
+# boost test files
+boost_test

--- a/2dview/src/2dview.cpp
+++ b/2dview/src/2dview.cpp
@@ -1,8 +1,8 @@
 /** To play the output .raw file using aplay run:
   * $aplay -t raw -c 2 -f cd -r 44100 output.raw */
 
-#include "../src/test.h"
-#include "../src/kfsys_interface.h"
+#include "../../src/test.h"
+#include "../../src/kfsys_interface.h"
 #include "view.h"
 
 #include <thread>
@@ -12,13 +12,13 @@
 
 #include <QApplication>
 
-#define NSOURCES 2
+#define NSOURCES 9
 
 using namespace std;
 
 int main(int argc, char **argv) {
 
-	string sound_file_path("../../sounds/input/");
+	string sound_file_path("../sounds/input/");
 	const char *sounds[] = {"cello", "clarinet","double_bass", "flute", "harp", "oboe", "percussion", "trombone", "violin"};
 	vector<string> sound_files(sounds, sounds + NSOURCES);
 	string file_type(".wav");
@@ -52,7 +52,7 @@ int main(int argc, char **argv) {
 	set_hrtf(3);
 	set_listener_position(0., -15., 1.);
 	set_listener_orientation(0., 0., -M_PI/2);
-	set_geometry("../../geometries/model.obj");
+	set_geometry("../geometries/model.obj");
 	set_reflection_order(1);
 	init_reverb();
 	set_reverb_rt60(2000);

--- a/2dview/src/view.cpp
+++ b/2dview/src/view.cpp
@@ -12,9 +12,9 @@
 #include <math.h> /* M_PI */
 
 #include "view.h"
-#include "../src/test.h"
+#include "../../src/test.h"
 
-#define NSOURCES 2
+#define NSOURCES 9
 
 View::View()
 	: QWidget()
@@ -218,7 +218,7 @@ void View::paintEvent(QPaintEvent *event)
 {
 	int x, y;
 
-	string image_file_path("../../images/");
+	string image_file_path("../images/");
 	const char *images[] = {"cello", "clarinet","double_bass", "flute", "harp", "oboe", "percussion", "trombone", "violin"};
 	vector<string> image_files(images, images + NSOURCES);
 	string file_type(".png");
@@ -279,7 +279,7 @@ void View::paintEvent(QPaintEvent *event)
 	}
 
 	/* Draw listener. */
-	static const QImage listenerImage("../../images/listener.png");
+	static const QImage listenerImage("../images/listener.png");
 	QTransform transform;
 	transform.rotate(yaw * (180 / M_PI));
 	QImage image = listenerImage.transformed(transform,	Qt::SmoothTransformation);

--- a/2dview/src/view.h
+++ b/2dview/src/view.h
@@ -2,7 +2,6 @@
  * view.h: view of the auralisation world
  * Copyright 2013 Universidade de Aveiro
  * Funded by FCT project AcousticAVE (PTDC/EEA-ELC/112137/2009)
- *
  * Written by Andre B. Oliveira <abo@ua.pt>
  */
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,31 +2,63 @@ cmake_minimum_required(VERSION 2.8)
 
 PROJECT(aave-audio-server)
 
-SET(SOURCES src/kfsys_interface.cpp src/alsa_interface.cpp src/aave_interface.cpp src/test.cpp src/kfsys_sound.cpp src/kfsys_source.cpp src/test.cpp src/util.cpp src/main_test_udp.cpp)
+SET(SERVER OFF)
+SET(2DVIEW ON)
+SET(PYTEST OFF)
+SET(BOOST_TEST OFF)
 
-FIND_LIBRARY(AAVE_LIBRARY libaave.a "../libaave")
+IF(PYTEST)
+	SET(SERVER ON)
+	SET(PYTHON_TEST_DIR /tests)
 
-SET(GCC_COMPILE_FLAGS "-std=c++11 -ggdb -O2")
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${GCC_COMPILE_FLAGS}")
+	macro(add_python_target tgt)
+	  foreach(file ${ARGN})
+		set(OUT ${CMAKE_CURRENT_BINARY_DIR}/${file}.pyo)
+		list(APPEND OUT_FILES ${OUT})
+		add_custom_command(OUTPUT ${OUT} COMMAND py.test -xv tests)
+	  endforeach()
 
-add_executable(${PROJECT_NAME} ${SOURCES})
+	  add_custom_target(${tgt} ALL DEPENDS ${OUT_FILES})
+	endmacro()
 
-target_link_libraries(${PROJECT_NAME} asound ${AAVE_LIBRARY})
+	add_python_target(tests ${PYTHON_TEST_DIR}/test_server.py)
+ENDIF(PYTEST)
 
-SET(PYTHON_TEST_DIR /tests)
+if(SERVER)
+	SET(SOURCES src/kfsys_interface.cpp src/alsa_interface.cpp src/aave_interface.cpp src/test.cpp src/kfsys_sound.cpp src/kfsys_source.cpp src/test.cpp src/util.cpp src/main_test_udp.cpp)
 
-macro(add_python_target tgt)
-  foreach(file ${ARGN})
-    set(OUT ${CMAKE_CURRENT_BINARY_DIR}/${file}.pyo)
-    list(APPEND OUT_FILES ${OUT})
-    add_custom_command(OUTPUT ${OUT} COMMAND py.test -xv tests)
-  endforeach()
+	FIND_LIBRARY(AAVE_LIBRARY libaave.a "../libaave")
 
-  add_custom_target(${tgt} ALL DEPENDS ${OUT_FILES})
-endmacro()
+	SET(GCC_COMPILE_FLAGS "-std=c++11 -ggdb -O2")
+	SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${GCC_COMPILE_FLAGS}")
 
-add_python_target(tests ${PYTHON_TEST_DIR}/test_server.py)
+	ADD_EXECUTABLE(aave-audio-server ${SOURCES})
+	TARGET_LINK_LIBRARIES(aave-audio-server asound ${AAVE_LIBRARY})
+endif(SERVER)
 
-#add_executable(boost_test src/boost_test.cpp src/kfsys_interface.cpp src/alsa_interface.cpp src/aave_interface.cpp src/test.cpp src/kfsys_sound.cpp src/kfsys_source.cpp src/test.cpp src/util.cpp)
+if(2DVIEW)
+	FIND_PACKAGE(Qt5Widgets REQUIRED)
+	SET(CMAKE_AUTOMOC ON)
 
-#target_link_libraries(boost_test asound ${AAVE_LIBRARY})
+	SET(GCC_COMPILE_FLAGS "-std=c++11 -ggdb -O2")
+	SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${GCC_COMPILE_FLAGS}")
+	FIND_LIBRARY(AAVE_LIBRARY libaave.a "../libaave")
+
+	SET(SOURCES_2DVIEW 2dview/src/2dview.cpp 2dview/src/view.cpp src/kfsys_interface.cpp src/alsa_interface.cpp src/aave_interface.cpp src/test.cpp src/kfsys_sound.cpp src/kfsys_source.cpp src/test.cpp src/util.cpp)
+
+	ADD_EXECUTABLE(2d_view ${SOURCES_2DVIEW})
+	TARGET_LINK_LIBRARIES(2d_view ${Qt5Widgets_LIBRARIES} asound ${AAVE_LIBRARY})
+ENDIF(2DVIEW)
+
+IF(BOOST_TEST)
+
+	FIND_LIBRARY(AAVE_LIBRARY libaave.a "../libaave")
+
+	SET(GCC_COMPILE_FLAGS "-std=c++11 -ggdb -O2")
+	SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${GCC_COMPILE_FLAGS}")
+
+	ADD_EXECUTABLE(boost_test src/boost_test.cpp src/kfsys_interface.cpp src/alsa_interface.cpp src/aave_interface.cpp src/test.cpp src/kfsys_sound.cpp src/kfsys_source.cpp src/test.cpp src/util.cpp)
+
+	TARGET_LINK_LIBRARIES(boost_test asound ${AAVE_LIBRARY})
+
+ENDIF(BOOST_TEST)


### PR DESCRIPTION
Just improved a bit the cmakelists.txt file. On top we can set which executable should be built by setting the corresponding variable on or off.
All executables compile and run with no problems.
